### PR TITLE
Reduce log spam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ publishing {
 
     repositories {
         maven {
-            url = "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases"
+            url = "https://nexus.gtnewhorizons.com/repository/releases/"
             credentials {
               username = System.getenv("MAVEN_USER") ?: "NONE"
               password = System.getenv("MAVEN_PASSWORD") ?: "NONE"

--- a/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -43,10 +43,14 @@ public class JavaMethod implements IJavaMethod {
             }
         }
         boolean lastOptional = false;
+        boolean errorDisplayed = false;
         for(int i = 0; i < optional.length; i++) {
             boolean opt = optional[i];
             if(lastOptional && !opt) {
-                System.err.println("All optionals need to be placed at the end of the method declaration: " + method.toGenericString() + "! Setting last parameters to optional");
+                if (!errorDisplayed) {
+                    System.err.println("All optionals need to be placed at the end of the method declaration: " + method.toGenericString() + "! Setting last parameters to optional");
+                    errorDisplayed = true;
+                }
                 optional[i] = lastOptional = true;
                 //throw new IllegalArgumentException("All optionals need to be placed at the end of the method declaration: " + method.toGenericString());
             } else {


### PR DESCRIPTION
## Summary
While working on https://github.com/GTNewHorizons/ModTweaker/pull/9, i noticed the errors were spammed once per non optional argument after an optional argument instead of once per signature. This PR adresses this.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
